### PR TITLE
Skip already downloaded files

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -31,7 +31,9 @@ LIST_URL = 'https://storage.googleapis.com/aist_plusplus_public/20121228/video_l
 
 def _download(video_url, download_folder):
   save_path = os.path.join(download_folder, os.path.basename(video_url))
-  urllib.request.urlretrieve(video_url, save_path)
+  # Skip already downloaded files (helpful to resume interrupted downloads)
+  if not os.path.exists(save_path):
+    urllib.request.urlretrieve(video_url, save_path)
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(


### PR DESCRIPTION
**Description:**
Skip already downloaded files (helpful to resume interrupted downloads)

**Additional Known Issues:**
With this method, it will not resume partially downloaded files.
Workout suggestions for this issue in the future.
-- If there is away to know expected file size then we could check for it. 
-- Each thread can save a last downloading file and remove them when done. Before resuming, delete all the incomplete files.
